### PR TITLE
1: Expand protected branches and add interactive setup

### DIFF
--- a/CLAUDE-git-sections.md
+++ b/CLAUDE-git-sections.md
@@ -2,6 +2,10 @@
 #
 # Add these sections to your global CLAUDE.md.
 # They define the git workflow conventions that all agents follow.
+#
+# Protected branches (blocked from direct commit/push):
+#   main, master, production, prod, staging, stag, develop, dev, release, trunk
+#   Plus any custom branches in ~/.claude/git-flow-protected-branches.json
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,29 @@ Issue -> Branch -> Implement -> Commit -> PR -> Merge -> Return to main
 - Every piece of work starts with a GitHub issue
 - Branches named `{issue-number}-{description}`
 - Commit messages formatted `{issue-number}: {description}`
-- No commits directly on `main` (must use feature branches)
-- No pushes to `main` (must use PRs)
+- No commits directly on protected branches (must use feature branches)
+- No pushes to protected branches (must use PRs)
 - Squash merges, delete branch on merge
 - No AI attribution in commits or PRs
+
+### Protected Branches
+
+The following branches are blocked from direct commits and pushes by default:
+
+| Branch | Common Use |
+|--------|-----------|
+| `main` | Primary branch (GitHub default) |
+| `master` | Primary branch (legacy default) |
+| `production` | Production deployment branch |
+| `prod` | Short form of production |
+| `staging` | Pre-production/QA environment |
+| `stag` | Short form of staging |
+| `develop` | Integration branch (git-flow) |
+| `dev` | Short form of develop |
+| `release` | Release preparation branch |
+| `trunk` | Primary branch (SVN/some teams) |
+
+**Custom branches** can be added during setup or later (see [Customization](#customization)).
 
 ## Quick Start
 
@@ -29,12 +48,14 @@ bash setup.sh
 ```
 
 The script will:
-1. Copy hook scripts to `~/.claude/hooks/`
-2. Copy slash commands to `~/.claude/commands/`
-3. Copy the protocols reference to `~/.claude/`
-4. Merge hook config into `~/.claude/settings.json`
-5. Detect conflicts with your existing config and back up before overwriting
-6. Print a full report of what was added/changed
+1. Show the default protected branches and prompt you to add more
+2. Scan your existing Claude config for branch protection rules and suggest additions
+3. Copy hook scripts to `~/.claude/hooks/`
+4. Copy slash commands to `~/.claude/commands/`
+5. Copy the protocols reference to `~/.claude/`
+6. Merge hook config into `~/.claude/settings.json`
+7. Detect conflicts with your existing config and back up before overwriting
+8. Print a full report of what was added/changed
 
 **Preview first** (no changes made):
 ```bash
@@ -131,9 +152,11 @@ A [`PreToolUse` hook](https://docs.anthropic.com/en/docs/claude-code/hooks) that
 
 | Action | Result |
 |--------|--------|
-| `git commit` on `main` | **BLOCKED** - must use feature branch |
+| `git commit` on any protected branch | **BLOCKED** - must use feature branch |
 | `git commit -m "no issue number"` | **BLOCKED** - must use `{issue}: {desc}` format |
-| `git push` to `main` | **BLOCKED** - must use PR workflow |
+| `git push` to any protected branch | **BLOCKED** - must use PR workflow |
+
+Protected branches: `main`, `master`, `production`, `prod`, `staging`, `stag`, `develop`, `dev`, `release`, `trunk` (plus any custom branches you add).
 
 Emergency bypass: `ALLOW_MAIN_COMMIT=1 git commit ...`
 
@@ -176,7 +199,7 @@ gh repo edit owner/repo \
 ```
 claude-git-flow/
   README.md                             # This file
-  setup.sh                              # Automated installer
+  setup.sh                              # Automated installer (interactive)
   CLAUDE-git-sections.md                # Git workflow rules for CLAUDE.md
   github-repo-protocols.md              # Full lifecycle reference
   hooks/
@@ -189,11 +212,27 @@ claude-git-flow/
     gs.md                               # /gs
     sync.md                             # /sync
     new-issue.md                        # /new-issue
+
+# Created during setup (in ~/.claude/):
+  git-flow-protected-branches.json      # Custom branches beyond the defaults
 ```
 
 ---
 
 ## Customization
+
+### Add custom protected branches
+
+During `setup.sh`, you'll be prompted to add extra branches. You can also edit the config file directly:
+
+```bash
+# ~/.claude/git-flow-protected-branches.json
+["qa", "uat", "hotfix", "demo"]
+```
+
+The hook reads this file at runtime and merges it with the built-in defaults. Changes take effect immediately (no reinstall needed).
+
+Alternatively, edit `~/.claude/hooks/enforce-git-workflow.py` and modify the `PROTECTED_BRANCHES` list directly.
 
 ### Allow direct-to-main for specific repos
 

--- a/hooks/enforce-git-workflow.py
+++ b/hooks/enforce-git-workflow.py
@@ -3,9 +3,9 @@
 PreToolUse:Bash hook to enforce GitHub Issues workflow.
 
 BLOCKS:
-1. Commits on main branch (must use feature branch)
+1. Commits on protected branches (must use feature branch)
 2. Commit messages without issue number prefix (^\d+:)
-3. Direct pushes to main branch (must use PR workflow)
+3. Direct pushes to protected branches (must use PR workflow)
 
 ESCAPE HATCHES:
 - ALLOW_MAIN_COMMIT=1 env var for emergencies
@@ -19,10 +19,42 @@ import re
 import subprocess
 import sys
 
+# ─── Protected branches ──────────────────────────────────────────────
+# Any branch matching one of these names (case-insensitive) is blocked
+# from direct commits and pushes. Use feature branches + PRs instead.
+#
+# To add custom branches, append to this list or use the setup script
+# which writes them to a config file.
+PROTECTED_BRANCHES = [
+    "main",
+    "master",
+    "production",
+    "prod",
+    "staging",
+    "stag",
+    "develop",
+    "dev",
+    "release",
+    "trunk",
+]
+
+# Load user-defined protected branches from config file (written by setup.sh)
+_CUSTOM_BRANCHES_FILE = os.path.expanduser(
+    "~/.claude/git-flow-protected-branches.json"
+)
+try:
+    with open(_CUSTOM_BRANCHES_FILE) as f:
+        _custom = json.load(f)
+        if isinstance(_custom, list):
+            PROTECTED_BRANCHES.extend(_custom)
+except (FileNotFoundError, json.JSONDecodeError, TypeError):
+    pass
+
+# Normalize to lowercase set for O(1) lookup
+PROTECTED_BRANCHES_SET = {b.lower() for b in PROTECTED_BRANCHES}
+
+# ─── Direct-to-main repos ────────────────────────────────────────────
 # Repos that use direct-to-main workflow (no feature branches, no issue numbers).
-# Matched against the git remote URL — any repo whose origin contains one of these
-# strings will skip all main-branch and commit-message checks.
-# Add repos that use direct-to-main workflow (no feature branches, no issue numbers).
 # Matched against the git remote URL. Example: "yourorg/your-dotfiles-repo"
 DIRECT_TO_MAIN_REPOS = [
     # "youruser/your-dotfiles",
@@ -42,6 +74,11 @@ def is_direct_to_main_repo():
     except Exception:
         pass
     return False
+
+
+def is_protected_branch(branch):
+    """Check if a branch name is in the protected list (case-insensitive)."""
+    return branch.lower() in PROTECTED_BRANCHES_SET
 
 
 def get_current_branch():
@@ -140,10 +177,11 @@ def check_commit(command, branch):
     if os.environ.get("ALLOW_MAIN_COMMIT") == "1":
         return
 
-    # Rule 1: No commits on main
-    if branch == "main":
+    # Rule 1: No commits on protected branches
+    if is_protected_branch(branch):
         deny(
-            "Cannot commit on main branch. Create a feature branch first:\n"
+            f"Cannot commit on protected branch '{branch}'. "
+            "Create a feature branch first:\n"
             "  1. gh issue create  (if no issue exists)\n"
             "  2. git checkout -b {issue-number}-{description}\n"
             "  3. Then commit\n\n"
@@ -175,18 +213,19 @@ def check_push(command, branch):
     if os.environ.get("ALLOW_MAIN_COMMIT") == "1":
         return
 
-    # Only block pushes when on main
-    if branch != "main":
+    # Only block pushes when on a protected branch
+    if not is_protected_branch(branch):
         return
 
-    # Parse what's being pushed to determine if it's actually pushing main
+    # Parse what's being pushed to determine if it's actually pushing
+    # the protected branch or an explicit different branch.
     # Allow: git push origin feature-branch (explicitly pushing a different branch)
     parts = command.split()
 
     # Find the refspec (what's being pushed)
-    # git push origin branch-name → pushing branch-name
-    # git push -u origin HEAD → pushing current branch (main)
-    # git push → pushing current branch (main)
+    # git push origin branch-name -> pushing branch-name
+    # git push -u origin HEAD -> pushing current branch
+    # git push -> pushing current branch
     push_target = None
     skip_next = False
     found_remote = False
@@ -214,17 +253,18 @@ def check_push(command, branch):
         push_target = part
         break
 
-    # HEAD means current branch (main), explicit branch name could differ
-    if push_target == "HEAD" or push_target == "main":
-        push_target = "main"
+    # HEAD means current branch, explicit branch name could differ
+    if push_target == "HEAD":
+        push_target = branch  # Resolves to current (protected) branch
     elif push_target is None:
-        # No explicit target → defaults to current branch (main)
-        push_target = "main"
-    elif push_target != "main":
-        return  # Pushing a specific non-main branch, allow
+        # No explicit target -> defaults to current branch
+        push_target = branch
+    elif not is_protected_branch(push_target):
+        return  # Pushing a specific non-protected branch, allow
 
     deny(
-        "Cannot push to main. Use the feature branch + PR workflow:\n"
+        f"Cannot push to protected branch '{branch}'. "
+        "Use the feature branch + PR workflow:\n"
         "  1. git checkout -b {issue-number}-{description}\n"
         "  2. Make changes and commit\n"
         "  3. git push -u origin HEAD\n"

--- a/setup.sh
+++ b/setup.sh
@@ -45,18 +45,22 @@ CONFLICTS=()
 SKIPPED=()
 DRY_RUN=false
 UNINSTALL=false
+NON_INTERACTIVE=false
+CUSTOM_BRANCHES_FILE="$CLAUDE_DIR/git-flow-protected-branches.json"
 
 # ─── Parse args ───────────────────────────────────────────────────────
 for arg in "$@"; do
   case $arg in
     --check|--dry-run) DRY_RUN=true ;;
     --uninstall) UNINSTALL=true ;;
+    --non-interactive|-y) NON_INTERACTIVE=true ;;
     --help|-h)
-      echo "Usage: bash setup.sh [--check|--uninstall|--help]"
+      echo "Usage: bash setup.sh [--check|--uninstall|--non-interactive|--help]"
       echo ""
-      echo "  --check      Dry run - show what would change without modifying anything"
-      echo "  --uninstall  Remove all installed components"
-      echo "  --help       Show this help message"
+      echo "  --check             Dry run - show what would change without modifying anything"
+      echo "  --uninstall         Remove all installed components"
+      echo "  --non-interactive   Skip prompts, use defaults (for agent-driven installs)"
+      echo "  --help              Show this help message"
       exit 0
       ;;
   esac
@@ -162,6 +166,12 @@ do_uninstall() {
     removed+=("github-repo-protocols.md")
   fi
 
+  # Remove custom branches config
+  if [ -f "$CUSTOM_BRANCHES_FILE" ]; then
+    rm "$CUSTOM_BRANCHES_FILE"
+    removed+=("git-flow-protected-branches.json")
+  fi
+
   # Note: We don't remove settings.json hooks entries automatically
   # because the user may have other hooks configured
 
@@ -179,6 +189,157 @@ do_uninstall() {
   fi
   echo ""
   exit 0
+}
+
+# ─── Configure protected branches ────────────────────────────────────
+configure_protected_branches() {
+  echo -e "${BOLD}0. Protected Branch Configuration${NC}"
+  echo "───────────────────────────────────────────"
+  echo ""
+  echo "  The following branches are protected by default (commits and"
+  echo "  pushes are blocked, forcing the feature-branch + PR workflow):"
+  echo ""
+  echo "    main, master, production, prod, staging, stag,"
+  echo "    develop, dev, release, trunk"
+  echo ""
+
+  # Scan existing Claude configs for branch protection hints
+  local detected_branches=()
+
+  # Check CLAUDE.md for branch references
+  if [ -f "$CLAUDE_DIR/CLAUDE.md" ]; then
+    # Look for patterns like "main branch", "deploy from X", "protected: X"
+    local found
+    found=$(grep -oiE '(deploy|push|merge)\s+(to|from|into)\s+["`'\'']*([a-zA-Z0-9._/-]+)["`'\'']*' "$CLAUDE_DIR/CLAUDE.md" 2>/dev/null | \
+      grep -oiE '[a-zA-Z0-9._/-]+$' | sort -u || true)
+    if [ -n "$found" ]; then
+      while IFS= read -r b; do
+        # Skip if already in default list
+        local is_default=false
+        for d in main master production prod staging stag develop dev release trunk; do
+          if [ "${b,,}" = "$d" ]; then is_default=true; break; fi
+        done
+        if ! $is_default && [ -n "$b" ]; then
+          detected_branches+=("$b")
+        fi
+      done <<< "$found"
+    fi
+  fi
+
+  # Check settings.json for branch protection patterns in deny rules
+  if [ -f "$SETTINGS_FILE" ]; then
+    local deny_branches
+    deny_branches=$(jq -r '.permissions.deny[]? // empty' "$SETTINGS_FILE" 2>/dev/null | \
+      grep -oiE 'git push.*(origin\s+)?([a-zA-Z0-9._/-]+)' | \
+      grep -oE '[a-zA-Z0-9._/-]+$' | sort -u || true)
+    if [ -n "$deny_branches" ]; then
+      while IFS= read -r b; do
+        local is_default=false
+        for d in main master production prod staging stag develop dev release trunk; do
+          if [ "${b,,}" = "$d" ]; then is_default=true; break; fi
+        done
+        if ! $is_default && [ -n "$b" ]; then
+          # Avoid duplicates with detected_branches
+          local already=false
+          for existing in "${detected_branches[@]}"; do
+            if [ "${existing,,}" = "${b,,}" ]; then already=true; break; fi
+          done
+          if ! $already; then
+            detected_branches+=("$b")
+          fi
+        fi
+      done <<< "$deny_branches"
+    fi
+  fi
+
+  # Check existing git-flow config for previously saved custom branches
+  if [ -f "$CUSTOM_BRANCHES_FILE" ]; then
+    local existing_custom
+    existing_custom=$(jq -r '.[]' "$CUSTOM_BRANCHES_FILE" 2>/dev/null || true)
+    if [ -n "$existing_custom" ]; then
+      while IFS= read -r b; do
+        local already=false
+        for existing in "${detected_branches[@]}"; do
+          if [ "${existing,,}" = "${b,,}" ]; then already=true; break; fi
+        done
+        if ! $already && [ -n "$b" ]; then
+          detected_branches+=("$b")
+        fi
+      done <<< "$existing_custom"
+    fi
+  fi
+
+  # Report detected branches
+  if [ ${#detected_branches[@]} -gt 0 ]; then
+    echo -e "  ${CYAN}Detected from your existing Claude config:${NC}"
+    for db in "${detected_branches[@]}"; do
+      echo "    + $db"
+    done
+    echo ""
+  fi
+
+  # Ask user for additional branches
+  if ! $DRY_RUN && ! $NON_INTERACTIVE; then
+    echo "  Enter additional branch names to protect (comma-separated),"
+    echo "  or press Enter to skip:"
+    echo ""
+    read -r -p "  Additional branches: " user_input
+
+    local all_custom=("${detected_branches[@]}")
+
+    if [ -n "$user_input" ]; then
+      # Split by comma, trim whitespace
+      IFS=',' read -ra user_branches <<< "$user_input"
+      for ub in "${user_branches[@]}"; do
+        ub=$(echo "$ub" | xargs)  # trim
+        if [ -n "$ub" ]; then
+          # Check not already in defaults
+          local is_default=false
+          for d in main master production prod staging stag develop dev release trunk; do
+            if [ "${ub,,}" = "$d" ]; then is_default=true; break; fi
+          done
+          if $is_default; then
+            log_skip "'$ub' is already in the default protected list"
+          else
+            # Check not duplicate
+            local already=false
+            for existing in "${all_custom[@]}"; do
+              if [ "${existing,,}" = "${ub,,}" ]; then already=true; break; fi
+            done
+            if ! $already; then
+              all_custom+=("$ub")
+            fi
+          fi
+        fi
+      done
+    fi
+
+    # Write custom branches to config file
+    if [ ${#all_custom[@]} -gt 0 ]; then
+      printf '%s\n' "${all_custom[@]}" | jq -R . | jq -s . > "$CUSTOM_BRANCHES_FILE"
+      CHANGES_MADE+=("git-flow-protected-branches.json - SAVED ${#all_custom[@]} custom branch(es): ${all_custom[*]}")
+      echo ""
+      log_success "Saved ${#all_custom[@]} custom protected branch(es): ${all_custom[*]}"
+    else
+      log_skip "No custom branches added (using defaults only)"
+    fi
+  elif $DRY_RUN; then
+    if [ ${#detected_branches[@]} -gt 0 ]; then
+      log_info "Would prompt to confirm detected branches: ${detected_branches[*]}"
+    else
+      log_info "Would prompt for additional protected branches"
+    fi
+  else
+    # Non-interactive mode - save detected branches if any
+    if [ ${#detected_branches[@]} -gt 0 ]; then
+      printf '%s\n' "${detected_branches[@]}" | jq -R . | jq -s . > "$CUSTOM_BRANCHES_FILE"
+      CHANGES_MADE+=("git-flow-protected-branches.json - AUTO-SAVED ${#detected_branches[@]} detected branch(es): ${detected_branches[*]}")
+      log_success "Auto-saved ${#detected_branches[@]} detected protected branch(es): ${detected_branches[*]}"
+    else
+      log_skip "No custom branches detected (using defaults only)"
+    fi
+  fi
+  echo ""
 }
 
 # ─── Install hooks ───────────────────────────────────────────────────
@@ -569,9 +730,12 @@ print_report() {
     echo "  4. /cpm  (or /commit then /pr then merge)"
     echo ""
     echo "  The hooks will block you if you try to:"
-    echo "    - Commit on main"
+    echo "    - Commit on a protected branch"
     echo "    - Commit without issue number prefix"
-    echo "    - Push directly to main"
+    echo "    - Push directly to a protected branch"
+    echo ""
+    echo "  Protected branches: main, master, production, prod, staging,"
+    echo "  stag, develop, dev, release, trunk (+ any custom branches)"
     echo ""
   fi
 
@@ -589,6 +753,7 @@ main() {
   fi
 
   preflight
+  configure_protected_branches
   install_hooks
   install_commands
   install_protocols


### PR DESCRIPTION
Closes #1

## Summary
- Expanded protected branches from just `main` to 10 defaults: main, master, production, prod, staging, stag, develop, dev, release, trunk
- Added interactive setup prompt that explains blocked branches and lets users add custom ones
- Setup script now scans existing Claude configs (CLAUDE.md, settings.json) to detect branch protection rules and suggest additions
- Custom branches saved to `~/.claude/git-flow-protected-branches.json` (loaded at runtime by the hook)
- Added `--non-interactive` flag for agent-driven installs
- Updated README with full protected branches table and customization docs
- Also updated the personal copy in claude-dotfiles